### PR TITLE
Prepare for Terraform 0.13 specific 2.x release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ terraform.tfvars
 terraform.tfvars.json
 *.auto.tfvars
 *.auto.tfvars.json
+
+# Don't commit foundations directory - just used for testing and not part of solution
+foundations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] and [1.3.0] - 2020-11-18
+
+> First of the parallel Terraform 0.13 and Terraform 0.12 specific releases.
+
+## Added
+
+## Changed
+
+- Enforcing Terraform 0.12.x or 0.13.x for 1.x and 2.x releases, respectively
+- Bumped Google provider to 3.48.0
+- Bumped Google IAM module to 6.4.0
+
+## Removed
+
 ## [1.2.2] - 2020-11-18
 
 ### Added
@@ -98,6 +112,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+[2.0.0]: https://github.com/memes/f5-google-terraform-modules/compare/v1.2.2...v2.0.0
+[1.3.0]: https://github.com/memes/f5-google-terraform-modules/compare/v1.2.2...v1.3.0
 [1.2.2]: https://github.com/memes/f5-google-terraform-modules/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/memes/f5-google-terraform-modules/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/memes/f5-google-terraform-modules/compare/v1.1.1...v1.2.0

--- a/README.md
+++ b/README.md
@@ -113,13 +113,13 @@ For guidelines and steps to diagnose deployment and run-time issues see
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.13.5 |
-| google | >= 3.47 |
+| google | >= 3.48 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| google | >= 3.47 |
+| google | >= 3.48 |
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -70,9 +70,10 @@ The BIG-IP modules all have a common set of requirements.
 
 1. Terraform 0.13.x
 
-   You are viewing a **2.x release** of the modules, which supports **Terraform 0.13**
-   only. *The 1.x releases support Terraform 0.12; functionality is identical but modules
-   are compatible with Terraform 0.12.*
+   > You are viewing a **2.x release** of the modules, which supports
+   > **Terraform 0.13** only. *For modules compatible with Terraform 0.12, use a
+   > 1.x release.* Functionality is identical, but separate releases are required
+   > due to the difference in *variable validation* between Terraform 0.12 and 0.13.
 
 2. Google Cloud [Secret Manager](https://cloud.google.com/secret-manager)
 

--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ the README files in each sub-module.
 
 The BIG-IP modules all have a common set of requirements.
 
-1. Terraform 0.12
+1. Terraform 0.13.x
 
-   A future version of these modules will target Terraform 0.13 once the majority
-   of module consumers request it. You can do this by adding a reaction to
-   tracking issue [#4](https://github.com/memes/terraform-google-f5-bigip/issues/4).
+   You are viewing a **2.x release** of the modules, which supports **Terraform 0.13**
+   only. *The 1.x releases support Terraform 0.12; functionality is identical but modules
+   are compatible with Terraform 0.12.*
 
 2. Google Cloud [Secret Manager](https://cloud.google.com/secret-manager)
 
@@ -112,7 +112,7 @@ For guidelines and steps to diagnose deployment and run-time issues see
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.12 |
+| terraform | ~> 0.13.5 |
 | google | >= 3.47 |
 
 ## Providers

--- a/examples/cfe-2nic/README.md
+++ b/examples/cfe-2nic/README.md
@@ -72,7 +72,7 @@ service_account    = "bigip@my-project-id.iam.gserviceaccount.com"
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.12 |
+| terraform | ~> 0.13.5 |
 
 ## Providers
 

--- a/examples/cfe-2nic/README.md
+++ b/examples/cfe-2nic/README.md
@@ -1,5 +1,10 @@
 # Cloud Failover Extension sub-module with 2-NIC deployment
 
+> You are viewing a **2.x release** of the modules, which supports
+> **Terraform 0.13** only. *For modules compatible with Terraform 0.12, use a
+> 1.x release.* Functionality is identical, but separate releases are required
+> due to the difference in *variable validation* between Terraform 0.12 and 0.13.
+
 This example demonstrates how to use the
 [CFE sub-module](https://registry.terraform.io/modules/memes/f5-bigip/google/latest/submodules/cfe)
 to deploy a pair of BIG-IP instances in a 2-NIC configuration, with

--- a/examples/cfe-2nic/main.tf
+++ b/examples/cfe-2nic/main.tf
@@ -4,15 +4,15 @@
 # Note: values to be updated by implementor are shown as [ITEM], where ITEM should
 # be changed to the correct resource name/identifier.
 
-# Only supported on Terraform 0.12
+# Only supported on Terraform 0.13
 terraform {
-  required_version = "~> 0.12"
+  required_version = "~> 0.13.5"
 }
 
 # Create a custom CFE role for BIG-IP service account
 module "cfe_role" {
   source      = "memes/f5-bigip/google//modules/cfe-role"
-  version     = "1.2.2"
+  version     = "2.0.0"
   target_type = "project"
   target_id   = var.project_id
   members     = [format("serviceAccount:%s", var.service_account)]
@@ -21,7 +21,7 @@ module "cfe_role" {
 # Create a firewall rule to allow BIG-IP ConfigSync and failover
 module "cfe_fw" {
   source                = "memes/f5-bigip/google//modules/configsync-fw"
-  version               = "1.2.2"
+  version               = "2.0.0"
   project_id            = var.project_id
   bigip_service_account = var.service_account
   dataplane_network     = var.external_network
@@ -86,7 +86,7 @@ module "cfe_bucket" {
 
 module "cfe" {
   source                            = "memes/f5-bigip/google//modules/cfe"
-  version                           = "1.2.2"
+  version                           = "2.0.0"
   project_id                        = var.project_id
   num_instances                     = var.num_instances
   zones                             = [var.zone]

--- a/examples/cfe-3nic/README.md
+++ b/examples/cfe-3nic/README.md
@@ -1,5 +1,10 @@
 # Cloud Failover Extension sub-module with 3-NIC deployment
 
+> You are viewing a **2.x release** of the modules, which supports
+> **Terraform 0.13** only. *For modules compatible with Terraform 0.12, use a
+> 1.x release.* Functionality is identical, but separate releases are required
+> due to the difference in *variable validation* between Terraform 0.12 and 0.13.
+
 This example demonstrates how to use the
 [CFE sub-module](https://registry.terraform.io/modules/memes/f5-bigip/google/latest/submodules/cfe)
 to deploy a pair of BIG-IP instances in a 3-NIC configuration, with

--- a/examples/cfe-3nic/README.md
+++ b/examples/cfe-3nic/README.md
@@ -77,7 +77,7 @@ service_account    = "bigip@my-project-id.iam.gserviceaccount.com"
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.12 |
+| terraform | ~> 0.13.5 |
 
 ## Providers
 

--- a/examples/cfe-3nic/main.tf
+++ b/examples/cfe-3nic/main.tf
@@ -4,15 +4,15 @@
 # Note: values to be updated by implementor are shown as [ITEM], where ITEM should
 # be changed to the correct resource name/identifier.
 
-# Only supported on Terraform 0.12
+# Only supported on Terraform 0.13
 terraform {
-  required_version = "~> 0.12"
+  required_version = "~> 0.13.5"
 }
 
 # Create a custom CFE role for BIG-IP service account
 module "cfe_role" {
   source      = "memes/f5-bigip/google//modules/cfe-role"
-  version     = "1.2.2"
+  version     = "2.0.0"
   target_type = "project"
   target_id   = var.project_id
   members     = [format("serviceAccount:%s", var.service_account)]
@@ -21,7 +21,7 @@ module "cfe_role" {
 # Create a firewall rule to allow BIG-IP ConfigSync and failover
 module "cfe_fw" {
   source                = "memes/f5-bigip/google//modules/configsync-fw"
-  version               = "1.2.2"
+  version               = "2.0.0"
   project_id            = var.project_id
   bigip_service_account = var.service_account
   dataplane_network     = var.internal_network
@@ -96,7 +96,7 @@ module "cfe_bucket" {
 
 module "cfe" {
   source                            = "memes/f5-bigip/google//modules/cfe"
-  version                           = "1.2.2"
+  version                           = "2.0.0"
   project_id                        = var.project_id
   num_instances                     = var.num_instances
   zones                             = [var.zone]

--- a/examples/ha-2nic/README.md
+++ b/examples/ha-2nic/README.md
@@ -1,5 +1,10 @@
 # High Availability sub-module with 2-NIC deployment
 
+> You are viewing a **2.x release** of the modules, which supports
+> **Terraform 0.13** only. *For modules compatible with Terraform 0.12, use a
+> 1.x release.* Functionality is identical, but separate releases are required
+> due to the difference in *variable validation* between Terraform 0.12 and 0.13.
+
 This example demonstrates how to use the
 [HA sub-module](https://registry.terraform.io/modules/memes/f5-bigip/google/latest/submodules/ha)
 to deploy a pair of BIG-IP instances in a 2-NIC configuration.

--- a/examples/ha-2nic/README.md
+++ b/examples/ha-2nic/README.md
@@ -61,7 +61,7 @@ service_account    = "bigip@my-project-id.iam.gserviceaccount.com"
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.12 |
+| terraform | ~> 0.13.5 |
 
 ## Providers
 

--- a/examples/ha-2nic/main.tf
+++ b/examples/ha-2nic/main.tf
@@ -4,15 +4,15 @@
 # Note: values to be updated by implementor are shown as [ITEM], where ITEM should
 # be changed to the correct resource name/identifier.
 
-# Only supported on Terraform 0.12
+# Only supported on Terraform 0.13
 terraform {
-  required_version = "~> 0.12"
+  required_version = "~> 0.13.5"
 }
 
 # Create a firewall rule to allow BIG-IP ConfigSync
 module "ha_fw" {
   source                = "memes/f5-bigip/google//modules/configsync-fw"
-  version               = "1.2.2"
+  version               = "2.0.0"
   project_id            = var.project_id
   bigip_service_account = var.service_account
   dataplane_network     = var.external_network
@@ -41,7 +41,7 @@ resource "google_compute_address" "mgt" {
 
 module "ha" {
   source                            = "memes/f5-bigip/google//modules/ha"
-  version                           = "1.2.2"
+  version                           = "2.0.0"
   project_id                        = var.project_id
   num_instances                     = var.num_instances
   zones                             = [var.zone]

--- a/examples/ha-3nic/README.md
+++ b/examples/ha-3nic/README.md
@@ -1,5 +1,10 @@
 # High Availability sub-module with 3-NIC deployment
 
+> You are viewing a **2.x release** of the modules, which supports
+> **Terraform 0.13** only. *For modules compatible with Terraform 0.12, use a
+> 1.x release.* Functionality is identical, but separate releases are required
+> due to the difference in *variable validation* between Terraform 0.12 and 0.13.
+
 This example demonstrates how to use the
 [HA sub-module](https://registry.terraform.io/modules/memes/f5-bigip/google/latest/submodules/ha)
 to deploy a pair of BIG-IP instances in a 3-NIC configuration.

--- a/examples/ha-3nic/README.md
+++ b/examples/ha-3nic/README.md
@@ -66,7 +66,7 @@ service_account    = "bigip@my-project-id.iam.gserviceaccount.com"
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.12 |
+| terraform | ~> 0.13.5 |
 
 ## Providers
 

--- a/examples/ha-3nic/main.tf
+++ b/examples/ha-3nic/main.tf
@@ -4,15 +4,15 @@
 # Note: values to be updated by implementor are shown as [ITEM], where ITEM should
 # be changed to the correct resource name/identifier.
 
-# Only supported on Terraform 0.12
+# Only supported on Terraform 0.13
 terraform {
-  required_version = "~> 0.12"
+  required_version = "~> 0.13.5"
 }
 
 # Create a firewall rule to allow BIG-IP ConfigSync
 module "ha_fw" {
   source                = "memes/f5-bigip/google//modules/configsync-fw"
-  version               = "1.2.2"
+  version               = "2.0.0"
   project_id            = var.project_id
   bigip_service_account = var.service_account
   dataplane_network     = var.internal_network
@@ -51,7 +51,7 @@ resource "google_compute_address" "int" {
 
 module "ha" {
   source                            = "memes/f5-bigip/google//modules/ha"
-  version                           = "1.2.2"
+  version                           = "2.0.0"
   project_id                        = var.project_id
   num_instances                     = var.num_instances
   zones                             = [var.zone]

--- a/examples/standalone-1nic/README.md
+++ b/examples/standalone-1nic/README.md
@@ -51,7 +51,7 @@ service_account    = "bigip@my-project-id.iam.gserviceaccount.com"
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.12 |
+| terraform | ~> 0.13.5 |
 
 ## Providers
 

--- a/examples/standalone-1nic/README.md
+++ b/examples/standalone-1nic/README.md
@@ -1,5 +1,10 @@
 # Standalone BIG-IP with single NIC deployment
 
+> You are viewing a **2.x release** of the modules, which supports
+> **Terraform 0.13** only. *For modules compatible with Terraform 0.12, use a
+> 1.x release.* Functionality is identical, but separate releases are required
+> due to the difference in *variable validation* between Terraform 0.12 and 0.13.
+
 This example demonstrates how to use the
 [BIG-IP module](https://registry.terraform.io/modules/memes/f5-bigip/google/latest)
 to deploy a single BIG-IP instance in a single NIC configuration.

--- a/examples/standalone-1nic/main.tf
+++ b/examples/standalone-1nic/main.tf
@@ -1,14 +1,14 @@
 # Example Terraform to create a single-NIC instance of BIG-IP using default
 # compute service account, and a Marketplace PAYG image.
 
-# Only supported on Terraform 0.12
+# Only supported on Terraform 0.13
 terraform {
-  required_version = "~> 0.12"
+  required_version = "~> 0.13.5"
 }
 
 module "instance" {
   source                            = "memes/f5-bigip/google"
-  version                           = "1.2.2"
+  version                           = "2.0.0"
   project_id                        = var.project_id
   zones                             = [var.zone]
   service_account                   = var.service_account

--- a/examples/standalone-2nic/README.md
+++ b/examples/standalone-2nic/README.md
@@ -1,5 +1,10 @@
 # Standalone BIG-IP with 2-NIC deployment
 
+> You are viewing a **2.x release** of the modules, which supports
+> **Terraform 0.13** only. *For modules compatible with Terraform 0.12, use a
+> 1.x release.* Functionality is identical, but separate releases are required
+> due to the difference in *variable validation* between Terraform 0.12 and 0.13.
+
 This example demonstrates how to use the
 [BIG-IP module](https://registry.terraform.io/modules/memes/f5-bigip/google/latest)
 to deploy a single BIG-IP instance in a 2-NIC configuration.

--- a/examples/standalone-2nic/README.md
+++ b/examples/standalone-2nic/README.md
@@ -53,7 +53,7 @@ service_account    = "bigip@my-project-id.iam.gserviceaccount.com"
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.12 |
+| terraform | ~> 0.13.5 |
 
 ## Providers
 

--- a/examples/standalone-2nic/main.tf
+++ b/examples/standalone-2nic/main.tf
@@ -4,14 +4,14 @@
 # Note: values to be updated by implementor are shown as [ITEM], where ITEM should
 # be changed to the correct resource name/identifier.
 
-# Only supported on Terraform 0.12
+# Only supported on Terraform 0.13
 terraform {
-  required_version = "~> 0.12"
+  required_version = "~> 0.13.5"
 }
 
 module "instance" {
   source                            = "memes/f5-bigip/google"
-  version                           = "1.2.2"
+  version                           = "2.0.0"
   project_id                        = var.project_id
   zones                             = [var.zone]
   service_account                   = var.service_account

--- a/examples/standalone-3nic/README.md
+++ b/examples/standalone-3nic/README.md
@@ -55,7 +55,7 @@ service_account    = "bigip@my-project-id.iam.gserviceaccount.com"
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.12 |
+| terraform | ~> 0.13.5 |
 
 ## Providers
 

--- a/examples/standalone-3nic/README.md
+++ b/examples/standalone-3nic/README.md
@@ -1,5 +1,10 @@
 # Standalone BIG-IP with 3-NIC deployment
 
+> You are viewing a **2.x release** of the modules, which supports
+> **Terraform 0.13** only. *For modules compatible with Terraform 0.12, use a
+> 1.x release.* Functionality is identical, but separate releases are required
+> due to the difference in *variable validation* between Terraform 0.12 and 0.13.
+
 This example demonstrates how to use the
 [BIG-IP module](https://registry.terraform.io/modules/memes/f5-bigip/google/latest)
 to deploy a single BIG-IP instance in a 3-NIC configuration.

--- a/examples/standalone-3nic/main.tf
+++ b/examples/standalone-3nic/main.tf
@@ -4,14 +4,14 @@
 # Note: values to be updated by implementor are shown as [ITEM], where ITEM should
 # be changed to the correct resource name/identifier.
 
-# Only supported on Terraform 0.12
+# Only supported on Terraform 0.13
 terraform {
-  required_version = "~> 0.12"
+  required_version = "~> 0.13.5"
 }
 
 module "instance" {
   source                = "memes/f5-bigip/google"
-  version               = "1.2.2"
+  version               = "2.0.0"
   project_id            = var.project_id
   zones                 = [var.zone]
   service_account       = var.service_account

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.12"
+  required_version = "~> 0.13.5"
   required_providers {
     google = ">= 3.47"
   }

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_version = "~> 0.13.5"
   required_providers {
-    google = ">= 3.47"
+    google = ">= 3.48"
   }
 }
 

--- a/modules/cfe-role/README.md
+++ b/modules/cfe-role/README.md
@@ -1,5 +1,10 @@
 # CFE-Role sub-module
 
+> You are viewing a **2.x release** of the modules, which supports
+> **Terraform 0.13** only. *For modules compatible with Terraform 0.12, use a
+> 1.x release.* Functionality is identical, but separate releases are required
+> due to the difference in *variable validation* between Terraform 0.12 and 0.13.
+
 This Terraform module is a helper to create a custom IAM role that has the
 minimal permissions required for Cloud Failover Extension to function correctly.
 The role will be created in the specified project by default, but can be created

--- a/modules/cfe-role/README.md
+++ b/modules/cfe-role/README.md
@@ -17,7 +17,7 @@ as an *Organization role* if preferred, for reuse across projects.
 ```hcl
 module "cfe_role" {
   source      = "memes/f5-bigip/google//modules/cfe-role"
-  version = "1.2.2"
+  version = "2.0.0"
   target_id   = "my-project-id"
   members     = ["serviceAccount:bigip@my-project-id.iam.gserviceaccount.com"]
 }
@@ -30,7 +30,7 @@ module "cfe_role" {
 ```hcl
 module "cfe_org_role" {
   source      = "memes/f5-bigip/google//modules/cfe-role"
-  version = "1.2.2"
+  version = "2.0.0"
   target_type = "org"
   target_id   = "my-org-id"
 }
@@ -44,7 +44,7 @@ module "cfe_org_role" {
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.12 |
+| terraform | ~> 0.13.5 |
 | google | >= 3.47 |
 
 ## Providers

--- a/modules/cfe-role/README.md
+++ b/modules/cfe-role/README.md
@@ -45,7 +45,7 @@ module "cfe_org_role" {
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.13.5 |
-| google | >= 3.47 |
+| google | >= 3.48 |
 
 ## Providers
 

--- a/modules/cfe-role/main.tf
+++ b/modules/cfe-role/main.tf
@@ -1,9 +1,8 @@
 terraform {
-  required_version = "~> 0.12"
+  required_version = "~> 0.13.5"
   required_providers {
     google = ">= 3.47"
   }
-  experiments = [variable_validation]
 }
 
 # Create a custom project role for CFE; BIG-IP service accounts will be granted

--- a/modules/cfe-role/main.tf
+++ b/modules/cfe-role/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_version = "~> 0.13.5"
   required_providers {
-    google = ">= 3.47"
+    google = ">= 3.48"
   }
 }
 
@@ -9,7 +9,7 @@ terraform {
 # this role, in addition to standard logging and monitoring roles.
 module "cfe_role" {
   source       = "terraform-google-modules/iam/google//modules/custom_role_iam"
-  version      = "6.3.1"
+  version      = "6.4.0"
   target_level = var.target_type
   target_id    = var.target_id
   role_id      = var.id

--- a/modules/cfe/README.md
+++ b/modules/cfe/README.md
@@ -54,7 +54,7 @@ module "cfe" {
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.13.5 |
-| google | >= 3.47 |
+| google | >= 3.48 |
 
 ## Providers
 

--- a/modules/cfe/README.md
+++ b/modules/cfe/README.md
@@ -1,5 +1,10 @@
 # BIG-IP cluster with Cloud Failover extension
 
+> You are viewing a **2.x release** of the modules, which supports
+> **Terraform 0.13** only. *For modules compatible with Terraform 0.12, use a
+> 1.x release.* Functionality is identical, but separate releases are required
+> due to the difference in *variable validation* between Terraform 0.12 and 0.13.
+
 This module encapsulates the creation of BIG-IP HA cluster with [Cloud Failover
 Extension](https://clouddocs.f5.com/products/extensions/f5-cloud-failover/latest/)
 to manage run-time update of GCP resources (routes, alias IPs, etc.) on failover

--- a/modules/cfe/README.md
+++ b/modules/cfe/README.md
@@ -23,7 +23,7 @@ resources that have the label `f5_cloud_failover_label` populated with value
 ```hcl
 module "cfe" {
   source                            = "memes/f5-bigip/google//modules/cfe"
-  version                           = "1.2.2"
+  version                           = "2.0.0"
   project_id                        = "my-project-id"
   num_instances                     = 2
   zones                             = ["us-central1-a", "us-central1-b"]
@@ -53,7 +53,7 @@ module "cfe" {
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.12 |
+| terraform | ~> 0.13.5 |
 | google | >= 3.47 |
 
 ## Providers

--- a/modules/cfe/main.tf
+++ b/modules/cfe/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_version = "~> 0.13.5"
   required_providers {
-    google = ">= 3.47"
+    google = ">= 3.48"
   }
 }
 locals {

--- a/modules/cfe/main.tf
+++ b/modules/cfe/main.tf
@@ -1,9 +1,8 @@
 terraform {
-  required_version = "~> 0.12"
+  required_version = "~> 0.13.5"
   required_providers {
     google = ">= 3.47"
   }
-  experiments = [variable_validation]
 }
 locals {
   cfe_payload = coalesce(var.cfe_payload, templatefile("${path.module}/templates/cfe.json", {

--- a/modules/configsync-fw/README.md
+++ b/modules/configsync-fw/README.md
@@ -61,13 +61,13 @@ module "configsync_fw" {
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.13.5 |
-| google | >= 3.47 |
+| google | >= 3.48 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| google | >= 3.47 |
+| google | >= 3.48 |
 
 ## Inputs
 

--- a/modules/configsync-fw/README.md
+++ b/modules/configsync-fw/README.md
@@ -24,7 +24,7 @@ defined.
 ```hcl
 module "configsync_fw" {
   source                = "memes/f5-bigip/google//modules/configsync-fw"
-  version               = "1.2.2"
+  version               = "2.0.0"
   project_id            = "my-project-id"
   bigip_service_account = "bigip@my-project-id.iam.gserviceaccount.com"
   dataplane_network     = "https://www.googleapis.com/compute/v1/projects/my-project-id/global/networks/external"
@@ -42,7 +42,7 @@ defined, using the `internal` network for ConfigSync traffic on data-plane.
 ```hcl
 module "configsync_fw" {
   source                   = "memes/f5-bigip/google//modules/configsync-fw"
-  version                  = "1.2.2"
+  version                  = "2.0.0"
   project_id               = "my-project-id"
   bigip_service_account    = "bigip@my-project-id.iam.gserviceaccount.com"
   dataplane_network        = "https://www.googleapis.com/compute/v1/projects/my-project-id/global/networks/internal"
@@ -60,7 +60,7 @@ module "configsync_fw" {
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.12 |
+| terraform | ~> 0.13.5 |
 | google | >= 3.47 |
 
 ## Providers

--- a/modules/configsync-fw/README.md
+++ b/modules/configsync-fw/README.md
@@ -1,5 +1,10 @@
 # HA ConfigSync firewall sub-module
 
+> You are viewing a **2.x release** of the modules, which supports
+> **Terraform 0.13** only. *For modules compatible with Terraform 0.12, use a
+> 1.x release.* Functionality is identical, but separate releases are required
+> due to the difference in *variable validation* between Terraform 0.12 and 0.13.
+
 This Terraform module is a helper to create a pair of firewall rules that allow
 ConfigSync traffic between BIG-IP instances on data-plane and control-plane
 networks.

--- a/modules/configsync-fw/main.tf
+++ b/modules/configsync-fw/main.tf
@@ -1,9 +1,8 @@
 terraform {
-  required_version = "~> 0.12"
+  required_version = "~> 0.13.5"
   required_providers {
     google = ">= 3.47"
   }
-  experiments = [variable_validation]
 }
 
 # Create a pair of service account limited firewall rules that support ConfigSync

--- a/modules/configsync-fw/main.tf
+++ b/modules/configsync-fw/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_version = "~> 0.13.5"
   required_providers {
-    google = ">= 3.47"
+    google = ">= 3.48"
   }
 }
 

--- a/modules/ha/README.md
+++ b/modules/ha/README.md
@@ -1,5 +1,10 @@
 # BIG-IP HA cluster module
 
+> You are viewing a **2.x release** of the modules, which supports
+> **Terraform 0.13** only. *For modules compatible with Terraform 0.12, use a
+> 1.x release.* Functionality is identical, but separate releases are required
+> due to the difference in *variable validation* between Terraform 0.12 and 0.13.
+
 This module encapsulates the creation of BIG-IP HA cluster with ConfigSync
 enabled.
 

--- a/modules/ha/README.md
+++ b/modules/ha/README.md
@@ -47,7 +47,7 @@ module "ha" {
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.13.5 |
-| google | >= 3.47 |
+| google | >= 3.48 |
 
 ## Providers
 

--- a/modules/ha/README.md
+++ b/modules/ha/README.md
@@ -19,7 +19,7 @@ This will create a pair of BIG-IP instances with ConfigSync enabled.
 ```hcl
 module "ha" {
   source                            = "memes/f5-bigip/google//modules/ha"
-  version                           = "1.2.2"
+  version                           = "2.0.0"
   project_id                        = "my-project-id"
   num_instances                     = 2
   zones                             = ["us-central1-a", "us-central1-b"]
@@ -46,7 +46,7 @@ module "ha" {
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.12 |
+| terraform | ~> 0.13.5 |
 | google | >= 3.47 |
 
 ## Providers

--- a/modules/ha/main.tf
+++ b/modules/ha/main.tf
@@ -1,9 +1,8 @@
 terraform {
-  required_version = "~> 0.12"
+  required_version = "~> 0.13.5"
   required_providers {
     google = ">= 3.47"
   }
-  experiments = [variable_validation]
 }
 
 locals {

--- a/modules/ha/main.tf
+++ b/modules/ha/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_version = "~> 0.13.5"
   required_providers {
-    google = ">= 3.47"
+    google = ">= 3.48"
   }
 }
 

--- a/modules/metadata/README.md
+++ b/modules/metadata/README.md
@@ -21,7 +21,7 @@ consumed by higher-order BIG-IP deployment modules.
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.12 |
+| terraform | ~> 0.13.5 |
 
 ## Providers
 

--- a/modules/metadata/README.md
+++ b/modules/metadata/README.md
@@ -1,5 +1,10 @@
 # BIG-IP metadata module
 
+> You are viewing a **2.x release** of the modules, which supports
+> **Terraform 0.13** only. *For modules compatible with Terraform 0.12, use a
+> 1.x release.* Functionality is identical, but separate releases are required
+> due to the difference in *variable validation* between Terraform 0.12 and 0.13.
+
 This module encapsulates the creation of a set of metadata entries common to
 BIG-IP Terraform modules as used in this repo. Embedding the required files and
 configuration options allows the various modules to override entries and customise

--- a/modules/metadata/main.tf
+++ b/modules/metadata/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.12"
+  required_version = "~> 0.13.5"
 }
 
 # Apply any required changes to metadata


### PR DESCRIPTION
Closes #4 

Makes changes to main that enforce Terraform 0.13 only. Includes bumping Google provider and dependent modules where needed.