### PR TITLE
Support cloud lib/extension installation on BIG-IP 15.1.1 and 15.1.2

### DIFF
--- a/examples/cfe-2nic-fqdn/README.md
+++ b/examples/cfe-2nic-fqdn/README.md
@@ -99,7 +99,7 @@ domain_name            = "example.com"
 | domain\_name | The domain name to use when setting FQDN of instances. | `string` | n/a | yes |
 | external\_network | The fully-qualified network self-link for the *external* network to which CFE<br>firewall rules will be deployed. | `string` | n/a | yes |
 | external\_subnet | The fully-qualified subnetwork self-link to attach to the BIG-IP VM \*external\*<br>interface. | `string` | n/a | yes |
-| image | The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps<br>release as of the publishing of this module. | `string` | `"projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"` | no |
+| image | The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps<br>release as of the publishing of this module. | `string` | `"projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"` | no |
 | instance\_name\_template | A format string that will be used when naming instance, that should include a<br>format token for including ordinal number. E.g. 'bigip-%d', such that %d will<br>be replaced with the ordinal of each instance. | `string` | n/a | yes |
 | management\_network | The fully-qualified network self-link for the *management* network to which CFE<br>firewall rules will be deployed. | `string` | n/a | yes |
 | management\_subnet | The fully-qualified subnetwork self-link to attach to the BIG-IP VM \*management\*<br>interface. | `string` | n/a | yes |

--- a/examples/cfe-2nic-fqdn/variables.tf
+++ b/examples/cfe-2nic-fqdn/variables.tf
@@ -61,7 +61,7 @@ EOD
 
 variable "image" {
   type        = string
-  default     = "projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"
+  default     = "projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"
   description = <<EOD
 The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps
 release as of the publishing of this module.

--- a/examples/cfe-2nic-hex-offset-fqdn/README.md
+++ b/examples/cfe-2nic-hex-offset-fqdn/README.md
@@ -101,7 +101,7 @@ domain_name             = "example.com"
 | domain\_name | The domain name to use when setting FQDN of instances. | `string` | n/a | yes |
 | external\_network | The fully-qualified network self-link for the *external* network to which CFE<br>firewall rules will be deployed. | `string` | n/a | yes |
 | external\_subnet | The fully-qualified subnetwork self-link to attach to the BIG-IP VM \*external\*<br>interface. | `string` | n/a | yes |
-| image | The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps<br>release as of the publishing of this module. | `string` | `"projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"` | no |
+| image | The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps<br>release as of the publishing of this module. | `string` | `"projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"` | no |
 | instance\_name\_template | A format string that will be used when naming instance, that should include a<br>format token for including ordinal number. E.g. 'bigip-%d', such that %d will<br>be replaced with the ordinal of each instance. | `string` | n/a | yes |
 | instance\_ordinal\_offset | The offset to apply to zero-based instance naming. | `number` | n/a | yes |
 | management\_network | The fully-qualified network self-link for the *management* network to which CFE<br>firewall rules will be deployed. | `string` | n/a | yes |

--- a/examples/cfe-2nic-hex-offset-fqdn/variables.tf
+++ b/examples/cfe-2nic-hex-offset-fqdn/variables.tf
@@ -61,7 +61,7 @@ EOD
 
 variable "image" {
   type        = string
-  default     = "projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"
+  default     = "projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"
   description = <<EOD
 The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps
 release as of the publishing of this module.

--- a/examples/cfe-2nic-multi-az/README.md
+++ b/examples/cfe-2nic-multi-az/README.md
@@ -94,7 +94,7 @@ service_account        = "bigip@my-project-id.iam.gserviceaccount.com"
 | admin\_password\_key | The Secret Manager key to lookup and retrive admin user password during<br>initialization. | `string` | n/a | yes |
 | external\_network | The fully-qualified network self-link for the *external* network to which CFE<br>firewall rules will be deployed. | `string` | n/a | yes |
 | external\_subnet | The fully-qualified subnetwork self-link to attach to the BIG-IP VM \*external\*<br>interface. | `string` | n/a | yes |
-| image | The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps<br>release as of the publishing of this module. | `string` | `"projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"` | no |
+| image | The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps<br>release as of the publishing of this module. | `string` | `"projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"` | no |
 | management\_network | The fully-qualified network self-link for the *management* network to which CFE<br>firewall rules will be deployed. | `string` | n/a | yes |
 | management\_subnet | The fully-qualified subnetwork self-link to attach to the BIG-IP VM \*management\*<br>interface. | `string` | n/a | yes |
 | num\_instances | The number of BIG-IP instances to create. Default is 2. | `number` | `2` | no |

--- a/examples/cfe-2nic-multi-az/variables.tf
+++ b/examples/cfe-2nic-multi-az/variables.tf
@@ -61,7 +61,7 @@ EOD
 
 variable "image" {
   type        = string
-  default     = "projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"
+  default     = "projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"
   description = <<EOD
 The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps
 release as of the publishing of this module.

--- a/examples/cfe-2nic/README.md
+++ b/examples/cfe-2nic/README.md
@@ -93,7 +93,7 @@ service_account    = "bigip@my-project-id.iam.gserviceaccount.com"
 | admin\_password\_key | The Secret Manager key to lookup and retrive admin user password during<br>initialization. | `string` | n/a | yes |
 | external\_network | The fully-qualified network self-link for the *external* network to which CFE<br>firewall rules will be deployed. | `string` | n/a | yes |
 | external\_subnet | The fully-qualified subnetwork self-link to attach to the BIG-IP VM \*external\*<br>interface. | `string` | n/a | yes |
-| image | The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps<br>release as of the publishing of this module. | `string` | `"projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"` | no |
+| image | The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps<br>release as of the publishing of this module. | `string` | `"projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"` | no |
 | management\_network | The fully-qualified network self-link for the *management* network to which CFE<br>firewall rules will be deployed. | `string` | n/a | yes |
 | management\_subnet | The fully-qualified subnetwork self-link to attach to the BIG-IP VM \*management\*<br>interface. | `string` | n/a | yes |
 | num\_instances | The number of BIG-IP instances to create. Default is 2. | `number` | `2` | no |

--- a/examples/cfe-2nic/variables.tf
+++ b/examples/cfe-2nic/variables.tf
@@ -61,7 +61,7 @@ EOD
 
 variable "image" {
   type        = string
-  default     = "projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"
+  default     = "projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"
   description = <<EOD
 The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps
 release as of the publishing of this module.

--- a/examples/cfe-3nic-fqdn-multi-az/README.md
+++ b/examples/cfe-3nic-fqdn-multi-az/README.md
@@ -104,7 +104,7 @@ domain_name            = "example.com"
 | admin\_password\_key | The Secret Manager key to lookup and retrive admin user password during<br>initialization. | `string` | n/a | yes |
 | domain\_name | The domain name to use when setting FQDN of instances. | `string` | n/a | yes |
 | external\_subnet | The fully-qualified subnetwork self-link to attach to the BIG-IP VM \*external\*<br>interface. | `string` | n/a | yes |
-| image | The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps<br>release as of the publishing of this module. | `string` | `"projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"` | no |
+| image | The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps<br>release as of the publishing of this module. | `string` | `"projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"` | no |
 | instance\_name\_template | A format string that will be used when naming instance, that should include a<br>format token for including ordinal number. E.g. 'bigip-%d', such that %d will<br>be replaced with the ordinal of each instance. | `string` | n/a | yes |
 | internal\_network | The fully-qualified network self-link for the *internal* network to which CFE<br>firewall rules will be deployed. | `string` | n/a | yes |
 | internal\_subnet | The fully-qualified subnetwork self-link to attach to the BIG-IP VM \*internal\*<br>interface. | `string` | n/a | yes |

--- a/examples/cfe-3nic-fqdn-multi-az/variables.tf
+++ b/examples/cfe-3nic-fqdn-multi-az/variables.tf
@@ -69,7 +69,7 @@ EOD
 
 variable "image" {
   type        = string
-  default     = "projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"
+  default     = "projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"
   description = <<EOD
 The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps
 release as of the publishing of this module.

--- a/examples/cfe-3nic/README.md
+++ b/examples/cfe-3nic/README.md
@@ -97,7 +97,7 @@ service_account    = "bigip@my-project-id.iam.gserviceaccount.com"
 |------|-------------|------|---------|:--------:|
 | admin\_password\_key | The Secret Manager key to lookup and retrive admin user password during<br>initialization. | `string` | n/a | yes |
 | external\_subnet | The fully-qualified subnetwork self-link to attach to the BIG-IP VM \*external\*<br>interface. | `string` | n/a | yes |
-| image | The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps<br>release as of the publishing of this module. | `string` | `"projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"` | no |
+| image | The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps<br>release as of the publishing of this module. | `string` | `"projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"` | no |
 | internal\_network | The fully-qualified network self-link for the *internal* network to which CFE<br>firewall rules will be deployed. | `string` | n/a | yes |
 | internal\_subnet | The fully-qualified subnetwork self-link to attach to the BIG-IP VM \*internal\*<br>interface. | `string` | n/a | yes |
 | management\_network | The fully-qualified network self-link for the *management* network to which CFE<br>firewall rules will be deployed. | `string` | n/a | yes |

--- a/examples/cfe-3nic/variables.tf
+++ b/examples/cfe-3nic/variables.tf
@@ -69,7 +69,7 @@ EOD
 
 variable "image" {
   type        = string
-  default     = "projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"
+  default     = "projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"
   description = <<EOD
 The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps
 release as of the publishing of this module.

--- a/examples/ha-2nic-1-based-fqdn/README.md
+++ b/examples/ha-2nic-1-based-fqdn/README.md
@@ -87,7 +87,7 @@ domain_name = "example.com"
 | domain\_name | The domain name to use when setting FQDN of instances. | `string` | n/a | yes |
 | external\_network | The fully-qualified network self-link for the *external* network to which HA<br>firewall rules will be deployed. | `string` | n/a | yes |
 | external\_subnet | The fully-qualified subnetwork self-link to attach to the BIG-IP VM \*external\*<br>interface. | `string` | n/a | yes |
-| image | The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps<br>release as of the publishing of this module. | `string` | `"projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"` | no |
+| image | The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps<br>release as of the publishing of this module. | `string` | `"projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"` | no |
 | instance\_name\_template | A format string that will be used when naming instance, that should include a<br>format token for including ordinal number. E.g. 'bigip-%d', such that %d will<br>be replaced with the ordinal of each instance. | `string` | n/a | yes |
 | instance\_ordinal\_offset | The offset to apply to zero-based instance naming. | `number` | n/a | yes |
 | management\_network | The fully-qualified network self-link for the *management* network to which HA<br>firewall rules will be deployed. | `string` | n/a | yes |

--- a/examples/ha-2nic-1-based-fqdn/variables.tf
+++ b/examples/ha-2nic-1-based-fqdn/variables.tf
@@ -61,7 +61,7 @@ EOD
 
 variable "image" {
   type        = string
-  default     = "projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"
+  default     = "projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"
   description = <<EOD
 The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps
 release as of the publishing of this module.

--- a/examples/ha-2nic-fqdn/README.md
+++ b/examples/ha-2nic-fqdn/README.md
@@ -82,7 +82,7 @@ service_account    = "bigip@my-project-id.iam.gserviceaccount.com"
 | domain\_name | The domain name to use when setting FQDN of instances. | `string` | n/a | yes |
 | external\_network | The fully-qualified network self-link for the *external* network to which HA<br>firewall rules will be deployed. | `string` | n/a | yes |
 | external\_subnet | The fully-qualified subnetwork self-link to attach to the BIG-IP VM \*external\*<br>interface. | `string` | n/a | yes |
-| image | The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps<br>release as of the publishing of this module. | `string` | `"projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"` | no |
+| image | The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps<br>release as of the publishing of this module. | `string` | `"projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"` | no |
 | instance\_name\_template | A format string that will be used when naming instance, that should include a<br>format token for including ordinal number. E.g. 'bigip-%d', such that %d will<br>be replaced with the ordinal of each instance. | `string` | n/a | yes |
 | management\_network | The fully-qualified network self-link for the *management* network to which HA<br>firewall rules will be deployed. | `string` | n/a | yes |
 | management\_subnet | The fully-qualified subnetwork self-link to attach to the BIG-IP VM \*management\*<br>interface. | `string` | n/a | yes |

--- a/examples/ha-2nic-fqdn/variables.tf
+++ b/examples/ha-2nic-fqdn/variables.tf
@@ -61,7 +61,7 @@ EOD
 
 variable "image" {
   type        = string
-  default     = "projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"
+  default     = "projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"
   description = <<EOD
 The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps
 release as of the publishing of this module.

--- a/examples/ha-2nic-multi-az/README.md
+++ b/examples/ha-2nic-multi-az/README.md
@@ -84,7 +84,7 @@ service_account    = "bigip@my-project-id.iam.gserviceaccount.com"
 | admin\_password\_key | The Secret Manager key to lookup and retrive admin user password during<br>initialization. | `string` | n/a | yes |
 | external\_network | The fully-qualified network self-link for the *external* network to which HA<br>firewall rules will be deployed. | `string` | n/a | yes |
 | external\_subnet | The fully-qualified subnetwork self-link to attach to the BIG-IP VM \*external\*<br>interface. | `string` | n/a | yes |
-| image | The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps<br>release as of the publishing of this module. | `string` | `"projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"` | no |
+| image | The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps<br>release as of the publishing of this module. | `string` | `"projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"` | no |
 | management\_network | The fully-qualified network self-link for the *management* network to which HA<br>firewall rules will be deployed. | `string` | n/a | yes |
 | management\_subnet | The fully-qualified subnetwork self-link to attach to the BIG-IP VM \*management\*<br>interface. | `string` | n/a | yes |
 | num\_instances | The number of BIG-IP instances to create. Default is 2. | `number` | `2` | no |

--- a/examples/ha-2nic-multi-az/variables.tf
+++ b/examples/ha-2nic-multi-az/variables.tf
@@ -61,7 +61,7 @@ EOD
 
 variable "image" {
   type        = string
-  default     = "projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"
+  default     = "projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"
   description = <<EOD
 The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps
 release as of the publishing of this module.

--- a/examples/ha-2nic/README.md
+++ b/examples/ha-2nic/README.md
@@ -81,7 +81,7 @@ service_account    = "bigip@my-project-id.iam.gserviceaccount.com"
 | admin\_password\_key | The Secret Manager key to lookup and retrive admin user password during<br>initialization. | `string` | n/a | yes |
 | external\_network | The fully-qualified network self-link for the *external* network to which HA<br>firewall rules will be deployed. | `string` | n/a | yes |
 | external\_subnet | The fully-qualified subnetwork self-link to attach to the BIG-IP VM \*external\*<br>interface. | `string` | n/a | yes |
-| image | The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps<br>release as of the publishing of this module. | `string` | `"projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"` | no |
+| image | The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps<br>release as of the publishing of this module. | `string` | `"projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"` | no |
 | management\_network | The fully-qualified network self-link for the *management* network to which HA<br>firewall rules will be deployed. | `string` | n/a | yes |
 | management\_subnet | The fully-qualified subnetwork self-link to attach to the BIG-IP VM \*management\*<br>interface. | `string` | n/a | yes |
 | num\_instances | The number of BIG-IP instances to create. Default is 2. | `number` | `2` | no |

--- a/examples/ha-2nic/variables.tf
+++ b/examples/ha-2nic/variables.tf
@@ -61,7 +61,7 @@ EOD
 
 variable "image" {
   type        = string
-  default     = "projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"
+  default     = "projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"
   description = <<EOD
 The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps
 release as of the publishing of this module.

--- a/examples/ha-3nic-fqdn-multi-az/README.md
+++ b/examples/ha-3nic-fqdn-multi-az/README.md
@@ -93,7 +93,7 @@ domain_name            = "example.com"
 | domain\_name | The domain name to use when setting FQDN of instances. | `string` | n/a | yes |
 | external\_network | The fully-qualified network self-link for the *external* network to which HA<br>firewall rules will be deployed. | `string` | n/a | yes |
 | external\_subnet | The fully-qualified subnetwork self-link to attach to the BIG-IP VM \*external\*<br>interface. | `string` | n/a | yes |
-| image | The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps<br>release as of the publishing of this module. | `string` | `"projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"` | no |
+| image | The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps<br>release as of the publishing of this module. | `string` | `"projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"` | no |
 | instance\_name\_template | A format string that will be used when naming instance, that should include a<br>format token for including ordinal number. E.g. 'bigip-%d', such that %d will<br>be replaced with the ordinal of each instance. | `string` | n/a | yes |
 | management\_network | The fully-qualified network self-link for the *management* network to which HA<br>firewall rules will be deployed. | `string` | n/a | yes |
 | management\_subnet | The fully-qualified subnetwork self-link to attach to the BIG-IP VM \*management\*<br>interface. | `string` | n/a | yes |

--- a/examples/ha-3nic-fqdn-multi-az/variables.tf
+++ b/examples/ha-3nic-fqdn-multi-az/variables.tf
@@ -61,7 +61,7 @@ EOD
 
 variable "image" {
   type        = string
-  default     = "projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"
+  default     = "projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"
   description = <<EOD
 The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps
 release as of the publishing of this module.

--- a/examples/ha-3nic/README.md
+++ b/examples/ha-3nic/README.md
@@ -85,7 +85,7 @@ service_account    = "bigip@my-project-id.iam.gserviceaccount.com"
 |------|-------------|------|---------|:--------:|
 | admin\_password\_key | The Secret Manager key to lookup and retrive admin user password during<br>initialization. | `string` | n/a | yes |
 | external\_subnet | The fully-qualified subnetwork self-link to attach to the BIG-IP VM \*external\*<br>interface. | `string` | n/a | yes |
-| image | The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps<br>release as of the publishing of this module. | `string` | `"projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"` | no |
+| image | The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps<br>release as of the publishing of this module. | `string` | `"projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"` | no |
 | internal\_network | The fully-qualified network self-link for the *internal* network to which HA<br>firewall rules will be deployed. | `string` | n/a | yes |
 | internal\_subnet | The fully-qualified subnetwork self-link to attach to the BIG-IP VM \*internal\*<br>interface. | `string` | n/a | yes |
 | management\_network | The fully-qualified network self-link for the *management* network to which HA<br>firewall rules will be deployed. | `string` | n/a | yes |

--- a/examples/ha-3nic/variables.tf
+++ b/examples/ha-3nic/variables.tf
@@ -69,7 +69,7 @@ EOD
 
 variable "image" {
   type        = string
-  default     = "projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"
+  default     = "projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"
   description = <<EOD
 The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps
 release as of the publishing of this module.

--- a/examples/standalone-1nic-fqdn-multi-az/README.md
+++ b/examples/standalone-1nic-fqdn-multi-az/README.md
@@ -68,7 +68,7 @@ No provider.
 |------|-------------|------|---------|:--------:|
 | admin\_password\_key | The Secret Manager key to lookup and retrive admin user password during<br>initialization. | `string` | n/a | yes |
 | domain\_name | The domain name to use when setting FQDN of instances. | `string` | n/a | yes |
-| image | The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps<br>release as of the publishing of this module. | `string` | `"projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"` | no |
+| image | The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps<br>release as of the publishing of this module. | `string` | `"projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"` | no |
 | instance\_name\_template | A format string that will be used when naming instance, that should include a<br>format token for including ordinal number. E.g. 'bigip-%d', such that %d will<br>be replaced with the ordinal of each instance. | `string` | n/a | yes |
 | project\_id | The GCP project identifier where the cluster will be created. | `string` | n/a | yes |
 | service\_account | The service account to use for BIG-IP VMs. | `string` | n/a | yes |

--- a/examples/standalone-1nic-fqdn-multi-az/variables.tf
+++ b/examples/standalone-1nic-fqdn-multi-az/variables.tf
@@ -36,7 +36,7 @@ EOD
 
 variable "image" {
   type        = string
-  default     = "projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"
+  default     = "projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"
   description = <<EOD
 The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps
 release as of the publishing of this module.

--- a/examples/standalone-1nic-metadata-admin-password/README.md
+++ b/examples/standalone-1nic-metadata-admin-password/README.md
@@ -80,7 +80,7 @@ No provider.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | admin\_password\_key | The metadata key to lookup and retrive admin user password during initialization. | `string` | n/a | yes |
-| image | The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps<br>release as of the publishing of this module. | `string` | `"projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"` | no |
+| image | The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps<br>release as of the publishing of this module. | `string` | `"projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"` | no |
 | metadata | Additional metadata values to pass to instances. For the demo that should include<br>an admin user password in cleartext associated with the key whose value matches<br>`admin_pasword_key`. | `map(string)` | n/a | yes |
 | project\_id | The GCP project identifier where the cluster will be created. | `string` | n/a | yes |
 | secret\_implementor | The implementation to use for secret retrieval. | `string` | n/a | yes |

--- a/examples/standalone-1nic-metadata-admin-password/variables.tf
+++ b/examples/standalone-1nic-metadata-admin-password/variables.tf
@@ -42,7 +42,7 @@ EOD
 
 variable "image" {
   type        = string
-  default     = "projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"
+  default     = "projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"
   description = <<EOD
 The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps
 release as of the publishing of this module.

--- a/examples/standalone-1nic/README.md
+++ b/examples/standalone-1nic/README.md
@@ -67,7 +67,7 @@ No provider.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | admin\_password\_key | The Secret Manager key to lookup and retrive admin user password during<br>initialization. | `string` | n/a | yes |
-| image | The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps<br>release as of the publishing of this module. | `string` | `"projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"` | no |
+| image | The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps<br>release as of the publishing of this module. | `string` | `"projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"` | no |
 | project\_id | The GCP project identifier where the cluster will be created. | `string` | n/a | yes |
 | service\_account | The service account to use for BIG-IP VMs. | `string` | n/a | yes |
 | subnet | The fully-qualified subnetwork self-link to attach to the BIG-IP VM. | `string` | n/a | yes |

--- a/examples/standalone-1nic/variables.tf
+++ b/examples/standalone-1nic/variables.tf
@@ -36,7 +36,7 @@ EOD
 
 variable "image" {
   type        = string
-  default     = "projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"
+  default     = "projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"
   description = <<EOD
 The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps
 release as of the publishing of this module.

--- a/examples/standalone-2nic/README.md
+++ b/examples/standalone-2nic/README.md
@@ -70,7 +70,7 @@ No provider.
 |------|-------------|------|---------|:--------:|
 | admin\_password\_key | The Secret Manager key to lookup and retrive admin user password during<br>initialization. | `string` | n/a | yes |
 | external\_subnet | The fully-qualified subnetwork self-link to attach to the BIG-IP VM \*external\*<br>interface. | `string` | n/a | yes |
-| image | The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps<br>release as of the publishing of this module. | `string` | `"projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"` | no |
+| image | The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps<br>release as of the publishing of this module. | `string` | `"projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"` | no |
 | management\_subnet | The fully-qualified subnetwork self-link to attach to the BIG-IP VM \*management\*<br>interface. | `string` | n/a | yes |
 | project\_id | The GCP project identifier where the cluster will be created. | `string` | n/a | yes |
 | service\_account | The service account to use for BIG-IP VMs. | `string` | n/a | yes |

--- a/examples/standalone-2nic/main.tf
+++ b/examples/standalone-2nic/main.tf
@@ -10,8 +10,11 @@ terraform {
 }
 
 module "instance" {
+  /* TODO m.emes@f5.com
   source                            = "memes/f5-bigip/google"
   version                           = "2.0.1"
+  */
+  source                            = "../../"
   project_id                        = var.project_id
   zones                             = [var.zone]
   service_account                   = var.service_account

--- a/examples/standalone-2nic/variables.tf
+++ b/examples/standalone-2nic/variables.tf
@@ -45,7 +45,7 @@ EOD
 
 variable "image" {
   type        = string
-  default     = "projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"
+  default     = "projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"
   description = <<EOD
 The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps
 release as of the publishing of this module.

--- a/examples/standalone-3nic-fqdn-1-based/README.md
+++ b/examples/standalone-3nic-fqdn-1-based/README.md
@@ -77,7 +77,7 @@ No provider.
 | admin\_password\_key | The Secret Manager key to lookup and retrive admin user password during<br>initialization. | `string` | n/a | yes |
 | domain\_name | The domain name to use when setting FQDN of instances. | `string` | n/a | yes |
 | external\_subnet | The fully-qualified subnetwork self-link to attach to the BIG-IP VM \*external\*<br>interface. | `string` | n/a | yes |
-| image | The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps<br>release as of the publishing of this module. | `string` | `"projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"` | no |
+| image | The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps<br>release as of the publishing of this module. | `string` | `"projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"` | no |
 | instance\_name\_template | A format string that will be used when naming instance, that should include a<br>format token for including ordinal number. E.g. 'bigip-%d', such that %d will<br>be replaced with the ordinal of each instance. | `string` | n/a | yes |
 | instance\_ordinal\_offset | The offset to apply to zero-based instance naming. | `number` | n/a | yes |
 | internal\_subnet | The fully-qualified subnetwork self-link to attach to the BIG-IP VM \*internal\*<br>interface. | `string` | n/a | yes |

--- a/examples/standalone-3nic-fqdn-1-based/variables.tf
+++ b/examples/standalone-3nic-fqdn-1-based/variables.tf
@@ -53,7 +53,7 @@ EOD
 
 variable "image" {
   type        = string
-  default     = "projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"
+  default     = "projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"
   description = <<EOD
 The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps
 release as of the publishing of this module.

--- a/examples/standalone-3nic/README.md
+++ b/examples/standalone-3nic/README.md
@@ -72,7 +72,7 @@ No provider.
 |------|-------------|------|---------|:--------:|
 | admin\_password\_key | The Secret Manager key to lookup and retrive admin user password during<br>initialization. | `string` | n/a | yes |
 | external\_subnet | The fully-qualified subnetwork self-link to attach to the BIG-IP VM \*external\*<br>interface. | `string` | n/a | yes |
-| image | The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps<br>release as of the publishing of this module. | `string` | `"projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"` | no |
+| image | The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps<br>release as of the publishing of this module. | `string` | `"projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"` | no |
 | internal\_subnet | The fully-qualified subnetwork self-link to attach to the BIG-IP VM \*internal\*<br>interface. | `string` | n/a | yes |
 | management\_subnet | The fully-qualified subnetwork self-link to attach to the BIG-IP VM \*management\*<br>interface. | `string` | n/a | yes |
 | project\_id | The GCP project identifier where the cluster will be created. | `string` | n/a | yes |

--- a/examples/standalone-3nic/variables.tf
+++ b/examples/standalone-3nic/variables.tf
@@ -53,7 +53,7 @@ EOD
 
 variable "image" {
   type        = string
-  default     = "projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"
+  default     = "projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"
   description = <<EOD
 The BIG-IP image to use. Defaults to the latest v15 PAYG/good/5gbps
 release as of the publishing of this module.

--- a/modules/cfe/README.md
+++ b/modules/cfe/README.md
@@ -41,7 +41,7 @@ module "cfe" {
   management_subnetwork_network_ips = ["10.0.1.10", "10.0.1.11"]
   internal_subnetworks              = ["projects/my-project-id/regions/us-central1/subnetworks/internal-central1"]
   internal_subnetwork_network_ips   = ["10.0.2.10", "10.0.2.11"]
-  image                             = "projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"
+  image                             = "projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"
   allow_phone_home                  = false
   allow_usage_analytics             = false
   admin_password_secret_manager_key = "bigip-admin-key"

--- a/modules/ha/README.md
+++ b/modules/ha/README.md
@@ -36,7 +36,7 @@ module "ha" {
   management_subnetwork_network_ips = ["10.0.1.10", "10.0.1.11"]
   internal_subnetworks              = ["projects/my-project-id/regions/us-central1/subnetworks/internal-central1"]
   internal_subnetwork_network_ips   = ["10.0.2.10", "10.0.2.11"]
-  image                             = "projects/f5-7626-networks-public/global/images/f5-bigip-15-0-1-3-0-0-4-payg-good-5gbps-200318182229"
+  image                             = "projects/f5-7626-networks-public/global/images/f5-bigip-15-1-2-0-0-9-payg-good-5gbps-201110225418"
   allow_phone_home                  = false
   allow_usage_analytics             = false
   admin_password_secret_manager_key = "bigip-admin-key"

--- a/modules/metadata/files/installCloudLibs.sh
+++ b/modules/metadata/files/installCloudLibs.sh
@@ -45,7 +45,7 @@ for url in "$@"; do
         https://storage.googleapis.com/*)
             auth_token="$(get_auth_token)" || \
                 error "Unable to get auth token: $?"
-            out="/var/tmp/$(basename "${url%%?alt=media}")"
+            out="/var/config/rest/downloads/$(basename "${url%%?alt=media}")"
             info "Downloading ${url} to ${out}"
             curl -sfL --retry 20 -o "${out}" \
                     -H "Authorization: Bearer ${auth_token}" \
@@ -53,7 +53,7 @@ for url in "$@"; do
                 error "Download of GCS file from ${url} failed: $?"
             ;;
         ftp://*|http://*|https://*)
-            out="/var/tmp/$(basename "${url}")"
+            out="/var/config/rest/downloads/$(basename "${url}")"
             info "Downloading ${url} to ${out}"
             curl -sfL --retry 20 -o "${out}" "${url}" || \
                 error "Download of ${url} failed with exit code: $?"


### PR DESCRIPTION
BIG-IP 15.1.1+ has tighter controls on the source path for RPM files installed via `package-management-tasks` API. This PR uses the sanctioned path for all uploads.

Closes #18 