### PR TITLE
Fix: lifecycle rule preventing replacement of VMs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -140,8 +140,4 @@ resource "google_compute_instance" "bigip" {
       }
     }
   }
-
-  lifecycle {
-    create_before_destroy = true
-  }
 }


### PR DESCRIPTION
Closes #46 for Terraform 0.13